### PR TITLE
Fix LSE in ticker guide

### DIFF
--- a/docs/compatibility.html
+++ b/docs/compatibility.html
@@ -257,7 +257,7 @@
 									<td><abbr title="London Stock Exchange">LSE</abbr> Stocks</td>
 									<td colspan="2">Google Finance</td>
 									<td class="hidden"></td>
-									<td><code>IST:</code> + ticker</td>
+									<td><code>LON:</code> + ticker</td>
 						    </tr>
 								<tr>
 						      <td>Russia</td>


### PR DESCRIPTION
This guide shows that you should use `IST: + ticker` for London stocks in `GOOGLEFINANCE`. However this should be `LON: + ticker`.