### PR TITLE
Minor changes for running and testing via clasp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .clasp.json
+.clasprc.json
+test.js

--- a/appsscript.json
+++ b/appsscript.json
@@ -7,5 +7,8 @@
     "https://www.googleapis.com/auth/script.container.ui",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/spreadsheets"
-   ]
+  ],
+  "executionApi": {
+    "access": "ANYONE"
+  }
 }


### PR DESCRIPTION
- Adds `.clasprc.json` to `.gitignore` to avoid commiting project credentials.
- Adds `test.js` to `.gitignore` to avoid commiting file used to run test functions.
- Updates project manifest to set `executionApi.access` to `ANYONE`.