### PR TITLE
Fix XML namespaces error by removing SVGs

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
     <div style="padding:10px;">
       <h1>µFunds</h1>
       <p><b>Authors:</b> José Ballester and <a href="https://github.com/joseballester/muFunds">the µFunds community at GitHub</a>.</p>
-      <p><b>Version:</b> v2.3.2</p>
+      <p><b>Version:</b> v2.4</p>
       <p>µFunds lets you import your mutual fund NAVs and other attributes from Morningstar and other sources to your Google Sheets spreadsheet by using a simple formula.</p>
 
       <h3 style="margin-top:25px;">Usage</h3>

--- a/helpers.js
+++ b/helpers.js
@@ -125,7 +125,10 @@ function fetchURL(url, cacheid, bodypos) {
       var xmlstr = fetch.getContentText()
                         .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
                         .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "")
-                        .replace("xml:space", "space");
+                        .replace("xml:space", "space")
+                        .replace("xmlns:", "")
+                        .replace("ns0:", "")
+                        .replace(/<svg(.*)<\/svg>/gm, '');
       var doc = Xml.parse(xmlstr, true);
       var body = doc.html.body;
       var bodyHtml = (body.length > bodypos ? body[bodypos].toXmlString() : body.toXmlString());

--- a/sources/morningstar-country.js
+++ b/sources/morningstar-country.js
@@ -98,12 +98,15 @@ function searchForMSID(id, country) {
         var xmlstr = fetch.getContentText()
                         .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
                         .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, "")
-                        .replace("xml:space", "space");
+                        .replace("xml:space", "space")
+                        .replace("xmlns:", "")
+                        .replace("ns0:", "")
+                        .replace(/<svg(.*)<\/svg>/gm, '');
         var doc = Xml.parse(xmlstr, true);
         var bodyHtml = doc.html.body;
         if(country == "uk" || country == "gb") bodyHtml = bodyHtml[2];
         bodyHtml = bodyHtml.toXmlString();
-        doc = XmlService.parse(bodyHtml) .getRootElement();
+        doc = XmlService.parse(bodyHtml).getRootElement();
         var links = getElementsByClassName(doc, getMorningstarCountrySearchResultClass(country));
         if(links.length > 0) {
           var msid = getMSIDFromMorningstarSearch(doc, links, country);


### PR DESCRIPTION
This pull request solves issue #21 by deleting elements with the `svg` tag within the loaded HTMLs. It turns out that a new SVG element, introduced recently in Morningstar country pages, had a non-compliant namespace attribute that made the XML parser fail.

This pull request updates µFunds to v2.4.

Closes #21.