### PR TITLE
Avoid HTTPS for morningstar-is

### DIFF
--- a/sources/morningstar.js
+++ b/sources/morningstar.js
@@ -25,7 +25,7 @@ function getMorningstarBase(country) {
   if(country == "ch")
     return "https://www.morningstar.ch/ch";
   if(country == "is")
-    return "https://www.morningstar.is/is";
+    return "http://www.morningstar.is/is";
   if(country == "it")
     return "https://www.morningstar.it/it";
   if(country == "pt")


### PR DESCRIPTION
Using HTTPS is leading to issues with `morningstar-is`. It seems that Morningstar closed its website for Iceland, and its HTTPS certificate was replaced for the UK website's, but snapshot pages for the country still work in HTTP.