### PR TITLE
Avoid caching for morningstar-uk

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -57,11 +57,14 @@ function processSource(source) {
 }
 
 /* -------- Fetching cached/non-cached pages -------- */
-function fetchURL(url, cacheid) {
+function fetchURL(url, cacheid = null) {
   const cache = CacheService.getScriptCache();
-  const cached = cache.get(cacheid);
-  if (cached != null) {
-    return cached;
+
+  if (cacheid != null) {
+    const cached = cache.get(cacheid);
+    if (cached != null) {
+      return cached;
+    }
   }
 
   const fetch = UrlFetchApp.fetch(url);
@@ -69,7 +72,11 @@ function fetchURL(url, cacheid) {
     const body = fetch.getContentText();
     const $ = Cheerio.load(body);
     const trimmed = $("body").html();
-    cache.put(cacheid, trimmed, 7200);
+
+    if (cacheid != null) {
+      cache.put(cacheid, trimmed, 7200);
+    }
+    
     return trimmed;
   } else {
     throw new Error("Wrong combination of asset identifier and source. Please check the accepted ones at the documentation.");

--- a/sources/morningstar.js
+++ b/sources/morningstar.js
@@ -193,7 +193,13 @@ function getCategoryFromMorningstar(doc, country) {
 
 function fetchMorningstar(id, country) {
   const url = getMorningstarLink(country, id);
-  const doc = fetchURL(url, "morningstar-" + country + "-" + id);
+
+  const cacheid = !['gb', 'uk'].includes(country)
+    ? "morningstar-" + country + "-" + id
+    : null;
+
+  const doc = fetchURL(url, cacheid);
+  
   return doc;
 }
 


### PR DESCRIPTION
It seems that snapshot pages for UK had a source code that was too long to be cached by Google Apps Script cache service. Caching has been temporarily disabled for `morningstar-uk`/`morningstar-gb` so results can be returned for this source. 